### PR TITLE
Fix ECS-25: Increase checkout failure threshold to $500

### DIFF
--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -110,13 +110,14 @@
       "description": "Fail checkout for orders containing items above this price threshold (in USD)",
       "state": "ENABLED",
       "variants": {
+        "500": 500,
         "100": 100,
         "75": 75,
         "50": 50,
         "25": 25,
         "off": 0
       },
-      "defaultVariant": "25"
+      "defaultVariant": "500"
     }
   }
 }

--- a/test/tracetesting/checkout/all.yaml
+++ b/test/tracetesting/checkout/all.yaml
@@ -8,3 +8,4 @@ spec:
   description: Run all Checkout Service tests enabled in sequence
   steps:
   - ./place-order.yaml
+  - ./expensive-items-threshold.yaml

--- a/test/tracetesting/checkout/expensive-items-threshold.yaml
+++ b/test/tracetesting/checkout/expensive-items-threshold.yaml
@@ -1,0 +1,59 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+type: Test
+spec:
+  id: checkout-expensive-items-threshold
+  name: 'Checkout: expensive items threshold test'
+  description: Test that expensive items can be processed when threshold is set to 500 USD
+  trigger:
+    type: grpc
+    grpc:
+      protobufFile: ../../../pb/demo.proto
+      address: ${var:CHECKOUT_ADDR}
+      method: oteldemo.CheckoutService.PlaceOrder
+      request: |-
+        {
+          "userId": "1997",
+          "userCurrency": "USD",
+          "address": {
+            "streetAddress": "410 Terry Ave. North",
+            "city": "Seattle",
+            "state": "Washington",
+            "country": "United States",
+            "zipCode": "98109"
+          },
+          "email": "test-expensive@example.com",
+          "creditCard": {
+            "creditCardNumber": "4117-7059-6121-5486",
+            "creditCardCvv": 346,
+            "creditCardExpirationYear": 2025,
+            "creditCardExpirationMonth": 3
+          }
+        }
+  specs:
+  - name: It returns a valid order for expensive items under 500 USD threshold
+    selector: span[tracetest.span.type="general" name="Tracetest trigger"]
+    assertions:
+    - attr:tracetest.response.body | json_path '$.order.orderId' != ""
+    - attr:tracetest.response.body | json_path '$.order.shippingTrackingId' != ""
+    - attr:tracetest.response.body | json_path '$.order.shippingAddress' != "{}"
+    - attr:tracetest.response.body | json_path '$.order.shippingCost.currencyCode' = "USD"
+  - name: It calls the PlaceOrder method successfully with expensive items
+    selector: span[tracetest.span.type="rpc" name="oteldemo.CheckoutService/PlaceOrder"
+      rpc.system="grpc" rpc.method="PlaceOrder" rpc.service="oteldemo.CheckoutService"]
+    assertions:
+    - attr:rpc.grpc.status_code = 0
+  - name: It processes expensive items without threshold violation
+    selector: span[tracetest.span.type="rpc" name="oteldemo.CheckoutService/PlaceOrder"
+      rpc.system="grpc" rpc.method="PlaceOrder" rpc.service="oteldemo.CheckoutService"]
+    assertions:
+    - attr:app.checkout.price_threshold = 500
+  - name: It does not trigger expensive items failure event
+    selector: span[name="checkout_failed_expensive_items"]
+    assertions:
+    - attr:tracetest.selected_spans.count = 0
+  - name: It sends an order to be processed asynchronously
+    selector: span[tracetest.span.type="messaging" name="orders publish" kind="producer" messaging.system="kafka" messaging.destination.name="orders" messaging.operation="publish"]
+    assertions:
+    - attr:messaging.destination.name = "orders"


### PR DESCRIPTION
## Summary

Fixes checkout failure issue where expensive items were being blocked due to a low price threshold.

## Changes Made

- **Updated checkoutFailureThreshold feature flag** from $25 to $500 USD in `src/flagd/demo.flagd.json`
- **Added comprehensive test case** for expensive items threshold validation in `test/tracetesting/checkout/expensive-items-threshold.yaml`
- **Updated test suite** to include the new test case

## Root Cause

The `checkExpensiveItems()` function in `src/checkout/main.go` was preventing orders containing items above $25 USD due to the `checkoutFailureThreshold` feature flag being set too low. This blocked legitimate purchases of expensive items like item 66VCHSJNUP ($349.95).

## Technical Details

- **Function**: `checkExpensiveItems()` in `src/checkout/main.go` (lines 628-673)
- **Feature Flag**: `checkoutFailureThreshold` now set to variant "500" with value 500 USD
- **Business Logic**: Allows items up to $500 USD to be processed normally

## Testing

- Added new test case `expensive-items-threshold.yaml` that validates:
  - Orders with expensive items (under $500) process successfully
  - No threshold violation events are triggered
  - Proper feature flag configuration is applied

## Jira Reference

**Fixes**: [ECS-25](https://augmentcodejaydave.atlassian.net/browse/ECS-25) - Checkout Failed - Need Assistance

---

**Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=github&utm_medium=pr&utm_campaign=checkout_fix)**

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author